### PR TITLE
Added checkboxes to select output format and medium

### DIFF
--- a/bsnes/ui-qt/debugger/debugger.cpp
+++ b/bsnes/ui-qt/debugger/debugger.cpp
@@ -259,6 +259,18 @@ Debugger::Debugger() {
   connect(debugSGB, SIGNAL(traceStateChanged(int)), tracer, SLOT(setSgbTraceState(int)));
   connect(traceMask->defaultAction(), SIGNAL(toggled(bool)), tracer, SLOT(setTraceMaskState(bool)));
 
+  connect(debugCPU, SIGNAL(traceFormatChanged(int)), tracer, SLOT(setTraceFormat(int)));
+  connect(debugSMP, SIGNAL(traceFormatChanged(int)), tracer, SLOT(setTraceFormat(int)));
+  connect(debugSA1, SIGNAL(traceFormatChanged(int)), tracer, SLOT(setTraceFormat(int)));
+  connect(debugSFX, SIGNAL(traceFormatChanged(int)), tracer, SLOT(setTraceFormat(int)));
+  connect(debugSGB, SIGNAL(traceFormatChanged(int)), tracer, SLOT(setTraceFormat(int)));
+
+  connect(debugCPU, SIGNAL(traceMediumChanged(int)), tracer, SLOT(setTraceMedium(int)));
+  connect(debugSMP, SIGNAL(traceMediumChanged(int)), tracer, SLOT(setTraceMedium(int)));
+  connect(debugSA1, SIGNAL(traceMediumChanged(int)), tracer, SLOT(setTraceMedium(int)));
+  connect(debugSFX, SIGNAL(traceMediumChanged(int)), tracer, SLOT(setTraceMedium(int)));
+  connect(debugSGB, SIGNAL(traceMediumChanged(int)), tracer, SLOT(setTraceMedium(int)));
+
   frameCounter = 0;
   synchronize();
   resize(855, 745);

--- a/bsnes/ui-qt/debugger/debuggerview.cpp
+++ b/bsnes/ui-qt/debugger/debuggerview.cpp
@@ -56,6 +56,18 @@ DebuggerView::DebuggerView(RegisterEdit *registers, DisasmProcessor *processor, 
   traceProcessor = new QCheckBox("Trace");
   controlLayout->addWidget(traceProcessor);
 
+  traceFormat = new QCheckBox("Text Output");
+  controlLayout->addWidget(traceFormat);
+
+  traceMedium = new QCheckBox("Socket Output");
+  controlLayout->addWidget(traceMedium);
+
+  // Text output
+  traceFormat->setChecked(false); 
+
+  // Socket output
+  traceMedium->setChecked(true); 
+
   if (processor->getSymbols() != NULL) {
     symbolsViewerDialog = new SymbolsView(processor);
     symbolsViewer = new QPushButton("Symbols");
@@ -67,6 +79,8 @@ DebuggerView::DebuggerView(RegisterEdit *registers, DisasmProcessor *processor, 
 
   connect(stepProcessor, SIGNAL(clicked(bool)), this, SLOT(synchronize()));
   connect(traceProcessor, SIGNAL(stateChanged(int)), this, SIGNAL(traceStateChanged(int)));
+  connect(traceFormat, SIGNAL(stateChanged(int)), this, SIGNAL(traceFormatChanged(int)));
+  connect(traceMedium, SIGNAL(stateChanged(int)), this, SIGNAL(traceMediumChanged(int)));
 
   connect(consoleLayout, SIGNAL(splitterMoved(int,int)), this, SLOT(synchronize()));
 

--- a/bsnes/ui-qt/debugger/debuggerview.moc.hpp
+++ b/bsnes/ui-qt/debugger/debuggerview.moc.hpp
@@ -9,6 +9,8 @@ public:
   QVBoxLayout *controlLayout;
   QCheckBox *stepProcessor;
   QCheckBox *traceProcessor;
+  QCheckBox *traceFormat;
+  QCheckBox *traceMedium; 
   QPushButton *symbolsViewer;
   class QHexEdit *ramViewer;
   class SymbolsView *symbolsViewerDialog;
@@ -26,6 +28,8 @@ public slots:
 signals:
   void synchronized();
   void traceStateChanged(int);
+  void traceFormatChanged(int);
+  void traceMediumChanged(int);
 
 protected:
   void resizeEvent(QResizeEvent*);

--- a/bsnes/ui-qt/debugger/tracer.cpp
+++ b/bsnes/ui-qt/debugger/tracer.cpp
@@ -3,18 +3,6 @@ Tracer *tracer;
 
 #include "w32_socket.cpp"
 
-// TODO: demo only: make these checkboxes in the UI or config options
-
-// tracer output info format
-// false: binary format (small/faster),
-// true:  text format (easier to parse / but slower and HUGE))
-const bool traceOutputFormatIsText = false;
-
-// where trace output will be sent
-// true: listen on a socket port and stream data to a client
-// false: output via a logfile on disk
-const bool traceOutputMediumIsSocket = true;
-
 #define DEFAULT_TRACE_SERVER_LISTEN_PORT "27015"
 
 void Tracer::outputTrace(const char* buf, int len) {
@@ -230,6 +218,16 @@ void Tracer::setTraceMaskState(bool state) {
   }
 }
 
+// Trace format  & medium
+
+void Tracer::setTraceFormat(int state) {
+  traceOutputFormatIsText = (state == Qt::Checked);
+}
+
+void Tracer::setTraceMedium(int state) {
+  traceOutputMediumIsSocket = (state == Qt::Checked);
+}
+
 Tracer::Tracer() {
   traceCpu = false;
   traceSmp = false;
@@ -237,6 +235,16 @@ Tracer::Tracer() {
   traceSfx = false;
   traceSgb = false;
   traceMask = false;
+
+  // tracer output info format
+  // false: binary format (small/faster),
+  // true:  text format (easier to parse / but slower and HUGE))
+  traceOutputFormatIsText = false;
+
+  // where trace output will be sent
+  // true: listen on a socket port and stream data to a client
+  // false: output via a logfile on disk
+  traceOutputMediumIsSocket = true;
 
   traceMaskCPU = new uint8_t[(1 << 24) >> 3]();
   traceMaskSMP = new uint8_t[(1 << 16) >> 3]();

--- a/bsnes/ui-qt/debugger/tracer.moc.hpp
+++ b/bsnes/ui-qt/debugger/tracer.moc.hpp
@@ -25,6 +25,9 @@ public slots:
 
   void flushTraceOutput();
 
+  void setTraceFormat(int);
+  void setTraceMedium(int);
+
 private:
   void setTraceState(bool);
 
@@ -37,6 +40,9 @@ private:
   bool traceSfx;
   bool traceSgb;
   bool traceMask;
+
+  bool traceOutputFormatIsText;
+  bool traceOutputMediumIsSocket;
 
   uint8_t *traceMaskCPU;
   uint8_t *traceMaskSMP;


### PR DESCRIPTION
Description:
This update introduces checkboxes to allow users to configure the trace output format and medium more easily. Previously, these options required manual configuration or were not as accessible.

Changes:
Added checkboxes to select different trace output formats.

Added a checkbox for choosing the output medium (e.g., file, socket).

Integrated these options into the UI for better usability.

This should improve flexibility and ease of use when configuring tracing options. 